### PR TITLE
feat(config): implement generic environment variable parser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,6 @@ CONTAINER_ID=local-dev
 # Webhook configuration
 WEBHOOK_URL=http://webhook.example.com/notify
 # Proxy configuration
-PROXY_TIMEOUT_SECONDS=30
+PROXY_TIMEOUT=30s # 30 seconds
 MAX_IDLE_CONNS=100
-IDLE_CONN_TIMEOUT_SECONDS=90 
+IDLE_CONN_TIMEOUT=90s # 90 seconds

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ CONTAINER_ID=local-dev
 # Webhook configuration
 WEBHOOK_URL=http://webhook.example.com/notify
 # Proxy configuration
-PROXY_TIMEOUT_SECONDS=30
+PROXY_TIMEOUT=30s # 30 seconds
 MAX_IDLE_CONNS=100
-IDLE_CONN_TIMEOUT_SECONDS=90
+IDLE_CONN_TIMEOUT=90s # 90 seconds
 ```
 
 Note: The `.env` file is not tracked in git for security reasons. Make sure to keep your environment files secure and never commit them to version control.

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -4,6 +4,6 @@ metadata:
   name: reverse-proxy-config
 data:
   RATE_LIMIT: "10"
-  PROXY_TIMEOUT_SECONDS: "45"
+  PROXY_TIMEOUT: "45s" # 45 seconds
   MAX_IDLE_CONNS: "100"
-  IDLE_CONN_TIMEOUT_SECONDS: "90" 
+  IDLE_CONN_TIMEOUT: "90s" # 90 seconds

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,32 +29,62 @@ func LoadConfig() (*Config, error) {
 
 	config := &Config{
 		BackendURL:      getEnv("BACKEND_URL", "http://localhost:8080"),
-		RateLimit:       getEnvAsInt("RATE_LIMIT", 10),
+		RateLimit:       getEnv("RATE_LIMIT", 10),
 		ContainerID:     getEnv("CONTAINER_ID", "unknown-container"),
 		WebhookURL:      getEnv("WEBHOOK_URL", ""),
-		ProxyTimeout:    time.Duration(getEnvAsInt("PROXY_TIMEOUT_SECONDS", 30)) * time.Second,
-		MaxIdleConns:    getEnvAsInt("MAX_IDLE_CONNS", 100),
-		IdleConnTimeout: time.Duration(getEnvAsInt("IDLE_CONN_TIMEOUT_SECONDS", 90)) * time.Second,
+		ProxyTimeout:    getEnv("PROXY_TIMEOUT", time.Second*30),
+		MaxIdleConns:    getEnv("MAX_IDLE_CONNS", 100),
+		IdleConnTimeout: getEnv("IDLE_CONN_TIMEOUT", time.Second*90),
 	}
 
 	return config, nil
 }
 
-// getEnv reads an environment variable with a default value
-func getEnv(key, defaultValue string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
+// getEnv is a generic function that retrieves and parses environment variables of different types.
+// It takes two parameters:
+//   - s: the name of the environment variable to retrieve
+//   - defaultValue: default value to return if environment variable is missing or invalid
+//
+// Returns parsed value of type T or the default value if parsing fails.
+func getEnv[T string | int | float64 | bool | time.Duration](s string, defaultValue T) T {
+	env := os.Getenv(s)
+	if env == "" {
+		return defaultValue
 	}
-	return defaultValue
-}
 
-// getEnvAsInt reads an environment variable as integer with a default value
-func getEnvAsInt(key string, defaultValue int) int {
-	if value := os.Getenv(key); value != "" {
-		if intValue, err := strconv.Atoi(value); err == nil {
-			return intValue
+	switch any(defaultValue).(type) {
+	case string:
+		return any(env).(T)
+	case int:
+		i, err := strconv.Atoi(env)
+		if err != nil {
+			log.Printf("Warning: Invalid integer value %s=%s, using default %v", s, env, defaultValue)
+			return defaultValue
 		}
-		log.Printf("Warning: Invalid integer value for %s, using default: %d", key, defaultValue)
+		return any(i).(T)
+	case float64:
+		f, err := strconv.ParseFloat(env, 64)
+		if err != nil {
+			log.Printf("Warning: Invalid float value %s=%s, using default %v", s, env, defaultValue)
+			return defaultValue
+		}
+		return any(f).(T)
+	case bool:
+		b, err := strconv.ParseBool(env)
+		if err != nil {
+			log.Printf("Warning: Invalid boolean value %s=%s, using default %v", s, env, defaultValue)
+			return defaultValue
+		}
+		return any(b).(T)
+	case time.Duration:
+		d, err := time.ParseDuration(env)
+		if err != nil {
+			log.Printf("Warning: Invalid duration value %s=%s, using default %v", s, env, defaultValue)
+			return defaultValue
+		}
+		return any(d).(T)
+	default:
+		log.Printf("Warning: Unsupported type %T for %s=%s, using default %v", defaultValue, s, env, defaultValue)
+		return defaultValue
 	}
-	return defaultValue
 }


### PR DESCRIPTION
# Generic environment variable parser with Go generics

First, thank you for this excellent project!

## What's changed

I've refactored the environment variable loading mechanism to use Go generics, simplifying the codebase while adding support for more data types:

- Replaced separate `getEnv` and `getEnvAsInt` functions with a single generic `getEnv[T]` function
- Simplified the Config initialization by directly using the generic function
- Changed time duration environment variables to use Go's native duration format (e.g., "400ms", "30s", "1m30s") instead of separate integer values

## Breaking Changes

- Time-related environment variables now expect Go duration format (e.g., "30s") instead of seconds as integers. The variables affected are:
  - `PROXY_TIMEOUT` (was `PROXY_TIMEOUT_SECONDS`)
  - `IDLE_CONN_TIMEOUT` (was `IDLE_CONN_TIMEOUT_SECONDS`)

Let me know if you need any changes or have questions!